### PR TITLE
Change per_page for groups to 100 (max)

### DIFF
--- a/services/my-service.js
+++ b/services/my-service.js
@@ -4,7 +4,7 @@ service('MyService', ['$http', function($http) {
 
      this.get = function(token, url){
         url = url || urlGlobal;
-        return $http.get(url + "/api/v4/groups", { headers: {
+        return $http.get(url + "/api/v4/groups?per_page=100", { headers: {
             'PRIVATE-TOKEN': token
           }});
      };


### PR DESCRIPTION
There are groups left unlisted when they are more than 20. I increased the amount to the maximum allowed per page